### PR TITLE
Fix: correct app config name and Reminder channel model reference

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -127,7 +127,7 @@ class Reminder(models.Model):
     remind_at = models.DateTimeField()
     # Change channel from CharField to ForeignKey
     channel = models.ForeignKey(
-        'chat.Channel',
+        'accounts.Channel',
         on_delete=models.SET_NULL,
         null=True, blank=True
         )

--- a/config/settings.py
+++ b/config/settings.py
@@ -40,11 +40,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'chat.apps.ChatConfig',
+    'chat.apps.MessagesConfig',
     'rooms',
     "channels",     #  Django Channels (library)
     "groups",       #  Our model for channels
-    'chat', # Add the (Chat App)
 
 ]
 


### PR DESCRIPTION
1. Fixed app config mismatch in settings.py

The settings file was referencing ChatConfig but the actual class name is MessagesConfig
Also removed a duplicate 'chat' entry in INSTALLED_APPS
2. Fixed incorrect model reference in accounts/models.py

Reminder.channel was pointing to 'chat.Channel' which doesn't exist
Changed it to 'accounts.Channel' where the Channel model is actually defined