### PR TITLE
Fix: add missing CSRF token to Create A Room form

### DIFF
--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -105,6 +105,7 @@
 
         <!-- Create a room (static) -->
         <form method="POST" class="flex gap-2 mt-4">
+            {% csrf_token %}
             <button type="submit" name="create_channel"
                 class="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm hover:bg-purple-700">
                 + Create A Room


### PR DESCRIPTION
Added {% csrf_token %} to the "Create A Room" form in the dashboard template.

Problem: Clicking the "+ Create A Room" button triggered a 403 Forbidden error (CSRF token missing).

Fix: Added the required {% csrf_token %} tag inside the form.

File changed: accounts/templates/accounts/dashboard.html