### PR TITLE
Fix: Dashboard Create Room button link and remove broken form

### DIFF
--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -103,14 +103,11 @@
             {% endfor %}
         </ul>
 
-        <!-- Create a room (static) -->
-        <form method="POST" class="flex gap-2 mt-4">
-            {% csrf_token %}
-            <button type="submit" name="create_channel"
-                class="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm hover:bg-purple-700">
-                + Create A Room
-            </button>
-        </form>
+        <!-- Create a room link -->
+        <a href="{% url 'rooms:create_room' %}"
+            class="inline-block px-4 py-2 bg-purple-600 text-white rounded-lg text-sm hover:bg-purple-700 mt-4">
+            + Create A Room
+        </a>
     </div>
 
     <!-- Pomodoro Status Card -->


### PR DESCRIPTION

This PR fixes two issues with the dashboard:

1. Fixed broken "Create A Room" button

The button was inside an empty form that submitted to the dashboard with no input fields
Changed it to a link that navigates to /rooms/create/ (the actual room creation page)
2. Removed unnecessary CSRF form

The original broken form required a CSRF token but served no purpose
Replaced with a simple <a> link, which doesn't need CSRF protection
File changed: accounts/templates/accounts/dashboard.html