### PR TITLE
Add inline edit and delete for messages.

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -47,14 +47,33 @@ class ChatConsumer(AsyncWebsocketConsumer):
             data = json.loads(text_data)
             message = data.get("message", "").strip()
             user = self.scope["user"]
+            msg_type = data.get("type", "chat")
 
             print(f"[WS] Message from {user}: {message}")
 
-            if not message or not user.is_authenticated:
-                print("[WS] Rejected - empty message or unauthenticated user")
+            if not user.is_authenticated:
+                print("[WS] Rejected - unauthenticated user")
+                return
+            
+            if msg_type == "edit":
+                await self.channel_layer.group_send(
+                    self.room_group_name,
+                    {"type": "message_edited", "message_id": data.get("message_id"), "content": data.get("content", "")},
+                )
                 return
 
-            await self.save_message(user, self.room_id, message)
+            if msg_type == "delete":
+                await self.channel_layer.group_send(
+                    self.room_group_name,
+                    {"type": "message_deleted", "message_id": data.get("message_id")},
+                )
+                return
+
+            if not message:
+                print("[WS] Rejected - empty message")
+                return            
+
+            save_id = await self.save_message(user, self.room_id, message)
 
             await self.channel_layer.group_send(
                 self.room_group_name,
@@ -62,6 +81,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
                     "type": "chat_message",
                     "message": message,
                     "username": user.username,
+                    "message_id": save_id,
                 },
             )
 
@@ -93,6 +113,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 conversation=conversation, user=user, content=content
             )
             print(f"[WS] Saved message id={msg.id}")
+            return msg.id
         except Conversation.DoesNotExist:
             print(f"[WS ERROR] Conversation not found for room_id={room_id}")
         except Exception as e:
@@ -105,3 +126,5 @@ class ChatConsumer(AsyncWebsocketConsumer):
         from .models import Conversation
 
         return Conversation.objects.filter(room_id=room_id, participants=user).exists()
+    
+

--- a/chat/templates/chat/chat.html
+++ b/chat/templates/chat/chat.html
@@ -24,13 +24,47 @@
         <!-- Messages Area -->
         <div id="chat-log" class="flex-1 overflow-y-auto p-6 space-y-4">
             {% for message in messages %}
-            {% if message.user == request.user %}
-            <!-- Sent message (right side) -->
+            {% if message.is_deleted %}
             <div class="flex justify-end">
-                <div class="max-w-md">
+                <p class="text-xs text-gray-400 italic px-4 py-2 bg-white/60 rounded-full border border-gray-200">
+                    This message was deleted.
+                </p>
+            </div>
+            {% elif message.user == request.user %}
+            <!-- Sent message (right side) -->
+            <div class="flex justify-end message-row group" data-msg-id="{{ message.id }}">
+                <div class="relative max-w-md">
+                    <!-- Action bar -->
+                    <div class="action-bar">
+                        <button onclick="startEdit('{{ message.id }}')" title="Edit message" class="action-btn">
+                            <span class="material-symbols-outlined text-[18px] text-purple-500">edit</span>
+                        </button>
+                        <button onclick="deleteMessage('{{ message.id }}')" title="Delete message" class="action-btn">
+                            <span class="material-symbols-outlined text-[18px] text-red-400">delete</span>
+                        </button>
+                    </div>
+
                     <p class="text-xs text-gray-400 text-right mb-1">{{ message.timestamp|timesince }} ago</p>
-                    <div class="msg-sent px-4 py-3 text-sm shadow-sm">
+                    <div id="msg-edit-{{ message.id }}" class="msg-sent px-4 py-3 text-sm shadow-sm">
                         {{ message.content }}
+                    </div>
+
+                    <!-- Inline edit -->
+                    <div id="edit-{{ message.id }}" class="hidden">
+                        <textarea id="edit-input-{{ message.id }}" class="w-full rounded-2xl px-4 py-3 text-sm text-gray-800
+               border-2 border-purple-400 focus:outline-none focus:border-purple-600
+               resize-none bg-white shadow-sm" rows="2">{{ message.content }}</textarea>
+                        <div class="flex gap-2 mt-1 justify-end">
+                            <button onclick="cancelEdit('{{ message.id }}')"
+                                class="text-xs text-gray-400 hover:text-gray-600 px-3 py-1 rounded-full border border-gray-200 bg-white">
+                                Cancel
+                            </button>
+                            <button onclick="submitEdit('{{ message.id }}')"
+                                class="text-xs text-white px-3 py-1 rounded-full"
+                                style="background: linear-gradient(135deg, #9B76B4 0%, #7c3aed 100%);">
+                                Save
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -38,8 +72,8 @@
             <!-- Received message (left side) -->
             <div class="flex gap-3">
                 {% if message.user.userprofile.avatar %}
-                <img class="rounded-full w-11 h-11 object-cover flex-shrink-0 mt-2" src="{{ message.user.userprofile.avatar.url }}"
-                    alt="Avatar">
+                <img class="rounded-full w-11 h-11 object-cover flex-shrink-0 mt-2"
+                    src="{{ message.user.userprofile.avatar.url }}" alt="Avatar">
                 {% else %}
                 <div class="flex items-center justify-center rounded-full w-11 h-11 bg-purple-100 flex-shrink-0">
                     <span class="material-symbols-outlined text-purple-600">person</span>
@@ -94,8 +128,6 @@
                 {{ room_name|first|upper }}
             </div>
             <h3 class="font-bold text-gray-800 text-lg">#{{ room_name }}</h3>
-            <p class="text-sm text-gray-400">{{ conversation.participants.count }} member{{
-                conversation.participants.count|pluralize }}</p>
         </div>
 
         <!-- Quick Links -->
@@ -165,6 +197,7 @@
     const roomName = "{{ room_name }}";
     const currentUser = "{{ request.user.username }}";
     const chatLog = document.getElementById('chat-log');
+    const csrfToken = "{{ csrf_token }}";
     chatLog.scrollTop = chatLog.scrollHeight;
 
     const socket = new WebSocket("ws://" + window.location.host + "/ws/chat/" + roomName + "/");
@@ -178,6 +211,23 @@
         const isSent = data.username === currentUser;
         const isOwn = data.username === "{{ request.user.username }}";
         const div = document.createElement('div');
+
+        // edit and delete for other user
+        if (data.type === 'message_edited') {
+            const bubble = document.getElementById(`msg-edit-${data.message_id}`);
+            if (bubble) bubble.textContent = data.content;
+            return;
+        }
+
+        if (data.type === 'message_deleted') {
+            const row = document.querySelector(`.message-row[data-msg-id="${data.message_id}"]`);
+            if (row) {
+                row.className = 'flex';
+                row.removeAttribute('data-msg-id');
+                row.innerHTML = `<p class="text-xs text-gray-400 italic px-4 py-2 bg-white/60 rounded-full border border-gray-200">This message was deleted.</p>`;
+            }
+            return;
+        }
 
         if (isSent) {
             // Sent message (right side, purple)
@@ -226,6 +276,58 @@
         socket.send(JSON.stringify({ message: msg }));
         input.value = '';
     }
+
+    function startEdit(id) {
+        document.getElementById(`msg-edit-${id}`).classList.add('hidden');
+        document.getElementById(`edit-${id}`).classList.remove('hidden');
+        const ta = document.getElementById(`edit-input-${id}`);
+        ta.focus();
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+    }
+
+    function cancelEdit(id) {
+        document.getElementById(`msg-edit-${id}`).classList.remove('hidden');
+        document.getElementById(`edit-${id}`).classList.add('hidden');
+    }
+
+    async function submitEdit(id) {
+        const content = document.getElementById(`edit-input-${id}`).value.trim();
+        if (!content) return;
+
+        const res = await fetch(`/chat/messages/${id}/edit/`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+            body: JSON.stringify({ content }),
+        });
+        const data = await res.json();
+
+        if (data.ok) {
+            document.getElementById(`msg-edit-${id}`).textContent = data.content;
+            cancelEdit(id);
+            socket.send(JSON.stringify({ type: 'edit', message_id: id, content: data.content }));
+        }
+    }
+
+    async function deleteMessage(id) {
+        if (!confirm('Delete this message?')) return;
+
+        const res = await fetch(`/chat/messages/${id}/delete/`, {
+            method: 'POST',
+            headers: { 'X-CSRFToken': csrfToken },
+        });
+        const data = await res.json();
+
+        if (data.ok) {
+            const row = document.querySelector(`.message-row[data-msg-id="${id}"]`);
+            if (row) {
+                row.className = 'flex justify-end';
+                row.removeAttribute('data-msg-id');
+                row.innerHTML = `<p class="text-xs text-gray-400 italic px-4 py-2 bg-white/60 rounded-full border border-gray-200">This message was deleted.</p>`;
+            }
+            socket.send(JSON.stringify({ type: 'delete', message_id: id }));
+        }
+    }
+
 </script>
 <style>
     body {
@@ -292,5 +394,45 @@
         background: #f3e8ff;
         color: #7c3aed;
     }
+
+    .action-bar {
+        position: absolute;
+        right: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        margin-right: 8px;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        opacity: 0;
+        pointer-events: none;
+        background: white;
+        border: 1px solid rgb(205, 197, 210);
+        border-radius: 15px;
+        padding: 4px;
+    }
+
+    .group:hover .action-bar {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .action-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        background: white;
+        cursor: pointer;
+        transition: all 0.15s;
+    }
+
+    .action-btn:hover {
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        transform: scale(1.1);
+    }
 </style>
+
 {% endblock %}

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -4,7 +4,9 @@ from . import views
 urlpatterns = [
     path("", views.inbox, name="inbox"),
     path("dm/<str:username>/", views.start_dm, name="start_dm"),
+    path("delete/<str:room_id>/", views.delete_conversation, name="delete_conversation"),
+    path("messages/<int:message_id>/edit/", views.edit_message, name="edit_message"),
+    path("messages/<int:message_id>/delete/", views.delete_message, name="delete_message"),
     path("<str:room_name>/", views.chat_room, name="chat_room"),
-   path("delete/<str:room_id>/", views.delete_conversation, name="delete_conversation"),
 
 ]

--- a/chat/views.py
+++ b/chat/views.py
@@ -2,6 +2,10 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
 from .models import Conversation, Message
+import json
+from django.http import JsonResponse
+from django.utils import timezone
+from django.views.decorators.http import require_POST
 
 User = get_user_model()
 
@@ -61,10 +65,8 @@ def chat_room(request, room_name):
         "other_user": other_user,
     })
 
-from django.shortcuts import get_object_or_404, redirect
-from django.contrib.auth.decorators import login_required
-
 @login_required
+@require_POST
 def delete_conversation(request, room_id):
     convo = get_object_or_404(Conversation, room_id=room_id)
 
@@ -73,3 +75,35 @@ def delete_conversation(request, room_id):
         convo.delete()
 
     return redirect('inbox')
+
+@login_required
+def edit_message(request, message_id):
+    msg = Message.objects.get(pk=message_id)
+
+    if msg.user != request.user:
+        return JsonResponse({"error": "Not allowed."}, status=403)
+
+    body = json.loads(request.body)
+    new_content = body.get("content", "").strip()
+
+    msg.content = new_content
+    msg.is_edited = True
+    msg.edited_at = timezone.now()
+    msg.save(update_fields=["content", "is_edited", "edited_at"])
+
+    return JsonResponse({"ok": True, "content": msg.content})
+
+
+@login_required
+def delete_message(request, message_id):
+    msg = Message.objects.get(pk=message_id)
+
+    if msg.user != request.user:
+        return JsonResponse({"error": "Not allowed."}, status=403)
+
+    msg.is_deleted = True
+    msg.deleted_at = timezone.now()
+    msg.content = ""
+    msg.save(update_fields=["is_deleted", "deleted_at", "content"])
+
+    return JsonResponse({"ok": True})


### PR DESCRIPTION
- In chat/views.py added edit_message and delete_message views
- Add edit and delete to chat/urls.py
- Update ChatConsumer to use edit and delete over Websocket
- Add hover action bar for edit and delete message
- Update socket.onmessage for real-time edit and delete updates
- Deleted message is rendered on page 

IMPORTANT NOTES
Currently, the delete confirmation prompt uses the brower's dialog rather than a custom one. This will be replaced with a modal in the future. 
Newly sent messages will not show the edit/delete hover until the page is hard-refreshed. Right now the inline JS for socket.onmessage is building that message HTML without the action bar included. In a future PR we will need to fix this so that the HTML does not need to be constructed manually in JS. The "message deleted" can remain in the inline JS just because it is a singular <p> tag, but the action bar is more complex and seems very bloated to add in the <script> tag for chat.html